### PR TITLE
Avoid circular imports

### DIFF
--- a/livekit/audio_source.py
+++ b/livekit/audio_source.py
@@ -1,4 +1,4 @@
-from livekit import AudioFrame
+from .audio_frame import AudioFrame
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import audio_frame_pb2 as proto_audio_frame

--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -2,7 +2,7 @@ import weakref
 
 from pyee.asyncio import AsyncIOEventEmitter
 
-from livekit import Track
+from .track import Track
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import audio_frame_pb2 as proto_audio_frame

--- a/livekit/participant.py
+++ b/livekit/participant.py
@@ -4,7 +4,7 @@ import weakref
 from typing import TYPE_CHECKING, List, Optional, Union
 from weakref import ref
 
-from livekit import DataPacketKind, TrackPublishOptions
+from ._proto.room_pb2 import DataPacketKind, TrackPublishOptions
 
 from ._ffi_client import ffi_client
 from ._proto import ffi_pb2 as proto_ffi
@@ -18,7 +18,7 @@ from .track_publication import (
 )
 
 if TYPE_CHECKING:
-    from livekit import Room
+    from .room import Room
 
 
 class PublishTrackError(Exception):

--- a/livekit/room.py
+++ b/livekit/room.py
@@ -4,7 +4,8 @@ import weakref
 
 from pyee.asyncio import AsyncIOEventEmitter
 
-from livekit import ConnectionState, TrackKind
+from ._proto.room_pb2 import ConnectionState
+from ._proto.track_pb2 import TrackKind
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi

--- a/livekit/track.py
+++ b/livekit/track.py
@@ -5,7 +5,8 @@ from ._proto import ffi_pb2 as proto_ffi
 from ._proto import track_pb2 as proto_track
 
 if TYPE_CHECKING:
-    from livekit import AudioSource, VideoSource
+    from .audio_source import AudioSource
+    from .video_source import VideoSource
 
 
 class Track():

--- a/livekit/track_publication.py
+++ b/livekit/track_publication.py
@@ -8,7 +8,7 @@ from ._proto import ffi_pb2 as proto_ffi
 from .track import Track
 
 if TYPE_CHECKING:
-    from livekit import LocalParticipant, RemoteParticipant
+    from .participant import LocalParticipant, RemoteParticipant
 
 
 class TrackPublication():

--- a/livekit/video_frame.py
+++ b/livekit/video_frame.py
@@ -1,6 +1,6 @@
 import ctypes
 
-from livekit import VideoFormatType, VideoFrameBufferType, VideoRotation
+from ._proto.video_frame_pb2 import VideoFormatType, VideoFrameBufferType, VideoRotation
 
 from ._ffi_client import ffi_client, FfiHandle
 from ._proto import ffi_pb2 as proto_ffi

--- a/livekit/video_source.py
+++ b/livekit/video_source.py
@@ -1,4 +1,4 @@
-from livekit import VideoFrame
+from .video_frame import VideoFrame
 
 from ._ffi_client import ffi_client, FfiHandle
 from ._proto import ffi_pb2 as proto_ffi

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -2,7 +2,7 @@ from weakref import ReferenceType, ref
 
 from pyee.asyncio import AsyncIOEventEmitter
 
-from livekit import Track
+from .track import Track
 
 from ._ffi_client import ffi_client, FfiHandle
 from ._proto import ffi_pb2 as proto_ffi


### PR DESCRIPTION
Doing absolute imports from livekit module can trigger circular import exceptions.
This PR replace all absolute imports from livekit by relative imports.