### PR TITLE
Allow asynchronous event callbacks

### DIFF
--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -14,7 +14,7 @@
 
 from weakref import WeakValueDictionary
 
-from pyee.asyncio import EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import audio_frame_pb2 as proto_audio_frame

--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -14,7 +14,7 @@
 
 from weakref import WeakValueDictionary
 
-from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import audio_frame_pb2 as proto_audio_frame
@@ -23,7 +23,7 @@ from .audio_frame import AudioFrame
 from .track import Track
 
 
-class AudioStream(EventEmitter):
+class AudioStream(AsyncIOEventEmitter):
     _streams: WeakValueDictionary[int, 'AudioStream'] = WeakValueDictionary()
     _initialized = False
 

--- a/livekit/room.py
+++ b/livekit/room.py
@@ -17,7 +17,7 @@ import ctypes
 from dataclasses import dataclass
 from typing import Optional
 
-from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi
@@ -41,7 +41,7 @@ class ConnectError(Exception):
         self.message = message
 
 
-class Room(EventEmitter):
+class Room(AsyncIOEventEmitter):
     def __init__(self) -> None:
         super().__init__()
         self.participants: dict[str, RemoteParticipant] = {}

--- a/livekit/room.py
+++ b/livekit/room.py
@@ -17,7 +17,7 @@ import ctypes
 from dataclasses import dataclass
 from typing import Optional
 
-from pyee.asyncio import EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -14,7 +14,7 @@
 
 from weakref import WeakValueDictionary
 
-from pyee.asyncio import EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -14,7 +14,7 @@
 
 from weakref import WeakValueDictionary
 
-from pyee.asyncio import AsyncIOEventEmitter as EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi
@@ -23,7 +23,7 @@ from .track import Track
 from .video_frame import VideoFrame, VideoFrameBuffer
 
 
-class VideoStream(EventEmitter):
+class VideoStream(AsyncIOEventEmitter):
     _streams: WeakValueDictionary[int, 'VideoStream'] = WeakValueDictionary()
     _initialized = False
 


### PR DESCRIPTION
In the current code, event callbacks cannot be async.
This PR is meant to be able to define async event callbacks.