### PR TITLE
fix: keep events order

### DIFF
--- a/examples/basic_room.py
+++ b/examples/basic_room.py
@@ -47,24 +47,18 @@ async def main() -> None:
                              participant: livekit.RemoteParticipant):
         logging.info("track unpublished: %s", publication.sid)
 
-    # Keep a reference to the streams, otherwise they will be disposed
-    audio_stream = None
-    video_stream = None
-
     @room.listens_to("track_subscribed")
     def on_track_subscribed(track: livekit.Track,
                             publication: livekit.RemoteTrackPublication,
                             participant: livekit.RemoteParticipant):
         logging.info("track subscribed: %s", publication.sid)
         if track.kind == livekit.TrackKind.KIND_VIDEO:
-            nonlocal video_stream
             video_stream = livekit.VideoStream(track)
             # video_stream is an async iterator that yields VideoFrame
         elif track.kind == livekit.TrackKind.KIND_AUDIO:
             print("Subscribed to an Audio Track")
-            nonlocal audio_stream
             audio_stream = livekit.AudioStream(track)
-            # audio_stream is an async iterator that yields AudioFrame 
+            # audio_stream is an async iterator that yields AudioFrame
 
     @room.listens_to("track_unsubscribed")
     def on_track_unsubscribed(track: livekit.Track,
@@ -142,10 +136,10 @@ if __name__ == "__main__":
                         logging.FileHandler("basic_room.log"), logging.StreamHandler()])
 
     loop = asyncio.get_event_loop()
-    main_task = asyncio.ensure_future(main())
+    asyncio.ensure_future(main())
     for signal in [SIGINT, SIGTERM]:
-        loop.add_signal_handler(signal, main_task.cancel)
+        loop.add_signal_handler(signal, loop.stop)
     try:
-        loop.run_until_complete(main_task)
+        loop.run_forever()
     finally:
         loop.close()

--- a/examples/basic_room.py
+++ b/examples/basic_room.py
@@ -114,21 +114,12 @@ async def main() -> None:
     def on_reconnected() -> None:
         logging.info("reconnected")
 
-    try:
-        logging.info("connecting to %s", URL)
-        await room.connect(URL, TOKEN)
-        logging.info("connected to room %s", room.name)
+    await room.connect(URL, TOKEN)
+    logging.info("connected to room %s", room.name)
+    logging.info("participants: %s", room.participants)
 
-        await room.local_participant.publish_data("hello world")
-
-        logging.info("participants: %s", room.participants)
-
-        await room.run()
-    except livekit.ConnectError as e:
-        logging.error("failed to connect to the room: %s", e)
-    except asyncio.CancelledError:
-        logging.info("closing the room")
-        await room.disconnect()
+    await asyncio.sleep(2)
+    await room.local_participant.publish_data("hello world")
 
 
 if __name__ == "__main__":

--- a/examples/basic_room.py
+++ b/examples/basic_room.py
@@ -6,7 +6,7 @@ from typing import Union
 import livekit
 
 URL = 'ws://localhost:7880'
-TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY'
+TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY'  # noqa
 
 
 async def main() -> None:
@@ -53,11 +53,11 @@ async def main() -> None:
                             participant: livekit.RemoteParticipant):
         logging.info("track subscribed: %s", publication.sid)
         if track.kind == livekit.TrackKind.KIND_VIDEO:
-            video_stream = livekit.VideoStream(track)
+            _video_stream = livekit.VideoStream(track)
             # video_stream is an async iterator that yields VideoFrame
         elif track.kind == livekit.TrackKind.KIND_AUDIO:
             print("Subscribed to an Audio Track")
-            audio_stream = livekit.AudioStream(track)
+            _audio_stream = livekit.AudioStream(track)
             # audio_stream is an async iterator that yields AudioFrame
 
     @room.listens_to("track_unsubscribed")

--- a/examples/e2ee.py
+++ b/examples/e2ee.py
@@ -9,6 +9,9 @@ import livekit
 URL = 'ws://localhost:7880'
 TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY'  # noqa
 
+# ("livekitrocks") this is our shared key, it must match the one used by your clients
+SHARED_KEY = b"livekitrocks"
+
 
 async def draw_cube(source: livekit.VideoSource):
     W, H, MID_W, MID_H = 1280, 720, 640, 360
@@ -65,9 +68,7 @@ async def main():
     logging.info("connecting to %s", URL)
     try:
         e2ee_options = livekit.E2EEOptions()
-
-        # ("livekitrocks") this is our shared key, use it on the client side
-        e2ee_options.key_provider_options.shared_key = b"livekitrocks"
+        e2ee_options.key_provider_options.shared_key = SHARED_KEY
 
         await room.connect(URL, TOKEN, options=livekit.RoomOptions(
             auto_subscribe=True,

--- a/examples/publish_hue.py
+++ b/examples/publish_hue.py
@@ -65,7 +65,8 @@ async def main():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, handlers=[
-                        logging.FileHandler("publish_hue.log"), logging.StreamHandler()])
+                        logging.FileHandler("publish_hue.log"),
+                        logging.StreamHandler()])
 
     loop = asyncio.get_event_loop()
     asyncio.ensure_future(main())

--- a/examples/publish_hue.py
+++ b/examples/publish_hue.py
@@ -58,21 +58,13 @@ async def main():
 
     # publish a track
     source = livekit.VideoSource()
-    source_task = asyncio.create_task(publish_frames(source))
-
     track = livekit.LocalVideoTrack.create_video_track("hue", source)
     options = livekit.TrackPublishOptions()
     options.source = livekit.TrackSource.SOURCE_CAMERA
     publication = await room.local_participant.publish_track(track, options)
     logging.info("published track %s", publication.sid)
 
-    try:
-        await room.run()
-    except asyncio.CancelledError:
-        logging.info("closing the room")
-        source_task.cancel()
-        await source_task
-        await room.disconnect()
+    asyncio.ensure_future(publish_frames(source))
 
 
 if __name__ == "__main__":
@@ -80,10 +72,10 @@ if __name__ == "__main__":
                         logging.FileHandler("publish_hue.log"), logging.StreamHandler()])
 
     loop = asyncio.get_event_loop()
-    main_task = asyncio.ensure_future(main())
+    asyncio.ensure_future(main())
     for signal in [SIGINT, SIGTERM]:
-        loop.add_signal_handler(signal, main_task.cancel)
+        loop.add_signal_handler(signal, loop.stop)
     try:
-        loop.run_until_complete(main_task)
+        loop.run_forever()
     finally:
         loop.close()

--- a/examples/publish_wave.py
+++ b/examples/publish_wave.py
@@ -7,7 +7,7 @@ import numpy as np
 import livekit
 
 URL = 'ws://localhost:7880'
-TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY'
+TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY'  # noqa
 
 SAMPLE_RATE = 48000
 NUM_CHANNELS = 1
@@ -61,7 +61,8 @@ async def main() -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, handlers=[
-                        logging.FileHandler("publish_wave.log"), logging.StreamHandler()])
+                        logging.FileHandler("publish_wave.log"),
+                        logging.StreamHandler()])
 
     loop = asyncio.get_event_loop()
     asyncio.ensure_future(main())

--- a/livekit/_ffi_client.py
+++ b/livekit/_ffi_client.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import ctypes
 import os
 import platform
 import threading
-from contextlib import contextmanager
-from typing import Callable, Generic, List, TypeVar
 
 import pkg_resources
+from _utils import BroadcastChannel
 
 from ._proto import ffi_pb2 as proto_ffi
 
@@ -74,52 +72,19 @@ class FfiHandle:
                 ctypes.c_uint64(self.handle))
 
 
-T = TypeVar('T')
-
-
-class FfiQueue(Generic[T]):
-    """ Queue where we can push events from another thread and 
-    pop them from an event_loop."""
-
-    def __init__(self, maxsize: int = 0) -> None:
-        # Get the current event loop where the queue is created
-        self._loop = asyncio.get_running_loop()
-        self._queue = asyncio.Queue[T](maxsize=maxsize)
-
-    def put(self, item: T):
-        self._loop.call_soon_threadsafe(self._queue.put_nowait, item)
-
-    async def get(self) -> T:
-        if self._loop != asyncio.get_running_loop():
-            raise RuntimeError(f'{self!r} is bound to a different event loop')
-
-        return await self._queue.get()
-
-    async def wait_for(self, fnc: Callable[[T], bool]) \
-            -> T:
-        """ Wait for an event that matches the given function.
-        The previous events are discarded.
-        """
-
-        while True:
-            event = await self.get()
-            if fnc(event):
-                return event
-
-
 @ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8), ctypes.c_size_t)
 def ffi_event_callback(data_ptr: ctypes.POINTER(ctypes.c_uint8),  # type: ignore
                        data_len: ctypes.c_size_t) -> None:
     event_data = bytes(data_ptr[:int(data_len)])
     event = proto_ffi.FfiEvent()
     event.ParseFromString(event_data)
-    ffi_client._push_event(event)
+    ffi_client.channel.put(event)
 
 
 class FfiClient:
     def __init__(self) -> None:
         self._lock = threading.RLock()
-        self._subscribers: List[FfiQueue[proto_ffi.FfiEvent]] = []
+        self._channel = BroadcastChannel[proto_ffi.FfiEvent]()
 
         # initialize request
         req = proto_ffi.FfiRequest()
@@ -128,30 +93,9 @@ class FfiClient:
         req.initialize.event_callback_ptr = cb_callback
         self.request(req)
 
-    def subscribe(self) -> FfiQueue[proto_ffi.FfiEvent]:
-        with self._lock:
-            queue = FfiQueue[proto_ffi.FfiEvent]()
-            self._subscribers.append(queue)
-            return queue
-
-    def unsubscribe(self, queue: FfiQueue[proto_ffi.FfiEvent]) -> None:
-        with self._lock:
-            self._subscribers.remove(queue)
-
-    @contextmanager
-    def observe(self):
-        queue = self.subscribe()
-        try:
-            yield queue
-        finally:
-            self.unsubscribe(queue)
-
-    def _push_event(self, event: proto_ffi.FfiEvent) -> None:
-        # emit to subscribers (all queue, like a spmc)
-        # this function is called from an undefined thread (from the Rust Tokio runtime)
-        with self._lock:
-            for queue in self._subscribers:
-                queue.put(event)
+    @property
+    def channel(self) -> BroadcastChannel[proto_ffi.FfiEvent]:
+        return self._channel
 
     def request(self, req: proto_ffi.FfiRequest) -> proto_ffi.FfiResponse:
         proto_data = req.SerializeToString()

--- a/livekit/_ffi_client.py
+++ b/livekit/_ffi_client.py
@@ -20,7 +20,7 @@ import threading
 import pkg_resources
 
 from ._proto import ffi_pb2 as proto_ffi
-from ._utils import BroadcastChannel
+from ._utils import ThreadsafeBroadcastQueue
 
 
 def get_ffi_lib_path():
@@ -84,7 +84,7 @@ def ffi_event_callback(data_ptr: ctypes.POINTER(ctypes.c_uint8),  # type: ignore
 class FfiClient:
     def __init__(self) -> None:
         self._lock = threading.RLock()
-        self._channel = BroadcastChannel[proto_ffi.FfiEvent]()
+        self._channel = ThreadsafeBroadcastQueue[proto_ffi.FfiEvent]()
 
         # initialize request
         req = proto_ffi.FfiRequest()
@@ -94,7 +94,7 @@ class FfiClient:
         self.request(req)
 
     @property
-    def channel(self) -> BroadcastChannel[proto_ffi.FfiEvent]:
+    def channel(self) -> ThreadsafeBroadcastQueue[proto_ffi.FfiEvent]:
         return self._channel
 
     def request(self, req: proto_ffi.FfiRequest) -> proto_ffi.FfiResponse:

--- a/livekit/_ffi_client.py
+++ b/livekit/_ffi_client.py
@@ -18,9 +18,9 @@ import platform
 import threading
 
 import pkg_resources
-from _utils import BroadcastChannel
 
 from ._proto import ffi_pb2 as proto_ffi
+from ._utils import BroadcastChannel
 
 
 def get_ffi_lib_path():

--- a/livekit/_utils.py
+++ b/livekit/_utils.py
@@ -1,6 +1,8 @@
 import asyncio
+import threading
 from collections import deque
-from typing import Generic, TypeVar
+from contextlib import contextmanager
+from typing import Callable, Generic, List, Optional, TypeVar
 
 T = TypeVar('T')
 
@@ -22,3 +24,82 @@ class RingQueue(Generic[T]):
             await self._event.wait()
         self._event.clear()
         return self._queue.popleft()
+
+
+class BroadcastQueue(Generic[T]):
+    def __init__(self) -> None:
+        self._subscribers: List[asyncio.Queue[T]] = []
+
+    def put_nowait(self, item: T) -> None:
+        for queue in self._subscribers:
+            queue.put_nowait(item)
+
+    def subscribe(self) -> asyncio.Queue[T]:
+        queue = asyncio.Queue[T]()
+        self._subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[T]) -> None:
+        self._subscribers.remove(queue)
+
+    @contextmanager
+    def observe(self):
+        queue = self.subscribe()
+        try:
+            yield queue
+        finally:
+            self.unsubscribe(queue)
+
+    async def join(self) -> None:
+        for queue in self._subscribers:
+            await queue.join()
+
+
+# thread safe variant of BroadcastQueue (lock + call_soon_threadsafe)
+# used by the FFI client to send events from a unknown thread to the corresponding
+# asyncio event loop
+class BroadcastChannel(Generic[T]):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._subscribers: List[asyncio.Queue[T]] = []
+
+    def put(self, item: T) -> None:
+        with self._lock:
+            for queue in self._subscribers:
+                loop: asyncio.AbstractEventLoop = queue._loop
+                loop.call_soon_threadsafe(queue.put_nowait, item)
+
+    def subscribe(self, loop: Optional[asyncio.AbstractEventLoop] = None) \
+            -> asyncio.Queue[T]:
+        with self._lock:
+            queue = asyncio.Queue[T]()
+            queue._loop = loop or asyncio.get_event_loop()
+            self._subscribers.append(queue)
+            return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[T]) -> None:
+        with self._lock:
+            self._subscribers.remove(queue)
+
+    @contextmanager
+    def observe(self):
+        queue = self.subscribe()
+        try:
+            yield queue
+        finally:
+            self.unsubscribe(queue)
+
+
+async def wait_for(queue: asyncio.Queue[T], fnc: Callable[[T], bool]) \
+        -> T:
+    """ Wait for an event that matches the given function.
+    The previous events are discarded.
+    """
+
+    while True:
+        event = await queue.get()
+        if fnc(event):
+            # task_done must be manually called for the returned item
+            return event
+
+        queue.task_done()

--- a/livekit/_utils.py
+++ b/livekit/_utils.py
@@ -30,6 +30,9 @@ class BroadcastQueue(Generic[T]):
     def __init__(self) -> None:
         self._subscribers: List[asyncio.Queue[T]] = []
 
+    def len_subscribers(self) -> int:
+        return len(self._subscribers)
+
     def put_nowait(self, item: T) -> None:
         for queue in self._subscribers:
             queue.put_nowait(item)

--- a/livekit/_utils.py
+++ b/livekit/_utils.py
@@ -66,10 +66,7 @@ class BroadcastQueue(Generic[T]):
             await queue.join()
 
 
-# thread safe variant of BroadcastQueue (lock + call_soon_threadsafe)
-# used by the FFI client to send events from a unknown thread to the corresponding
-# asyncio event loop
-class BroadcastChannel(Generic[T]):
+class ThreadsafeBroadcastQueue(Generic[T]):
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._subscribers: List[Queue[T]] = []

--- a/livekit/audio_source.py
+++ b/livekit/audio_source.py
@@ -36,7 +36,7 @@ class AudioSource:
         req.capture_audio_frame.source_handle = self._ffi_handle.handle
         req.capture_audio_frame.buffer.CopyFrom(frame._proto_info())
 
-        with ffi_client.observe() as obs:
+        with ffi_client.channel.observe() as obs:
             resp = ffi_client.request(req)
             cb = await obs.wait_for(lambda e: e.capture_audio_frame.async_id ==
                                     resp.capture_audio_frame.async_id)

--- a/livekit/audio_source.py
+++ b/livekit/audio_source.py
@@ -36,10 +36,13 @@ class AudioSource:
         req.capture_audio_frame.source_handle = self._ffi_handle.handle
         req.capture_audio_frame.buffer.CopyFrom(frame._proto_info())
 
-        with ffi_client.channel.observe() as obs:
+        try:
+            queue = ffi_client.queue.subscribe()
             resp = ffi_client.request(req)
-            cb = await obs.wait_for(lambda e: e.capture_audio_frame.async_id ==
-                                    resp.capture_audio_frame.async_id)
+            cb = await queue.wait_for(lambda e: e.capture_audio_frame.async_id ==
+                                      resp.capture_audio_frame.async_id)
+        finally:
+            ffi_client.queue.unsubscribe(queue)
 
         if cb.capture_audio_frame.error:
             raise Exception(cb.capture_audio_frame.error)

--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -29,7 +29,7 @@ class AudioStream:
                  capacity: int = 0) -> None:
         self._track = track
         self._loop = loop or asyncio.get_event_loop()
-        self._ffi_queue = ffi_client.subscribe(self._loop)
+        self._ffi_queue = ffi_client.channel.subscribe(self._loop)
         self._queue: RingQueue[AudioFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()

--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -29,7 +29,7 @@ class AudioStream:
                  capacity: int = 0) -> None:
         self._track = track
         self._loop = loop or asyncio.get_event_loop()
-        self._ffi_queue = ffi_client.channel.subscribe(self._loop)
+        self._ffi_queue = ffi_client.queue.subscribe(self._loop)
         self._queue: RingQueue[AudioFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()

--- a/livekit/audio_stream.py
+++ b/livekit/audio_stream.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from typing import Optional
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import audio_frame_pb2 as proto_audio_frame
@@ -23,9 +24,12 @@ from .track import Track
 
 
 class AudioStream:
-    def __init__(self, track: Track, capacity: int = 0) -> None:
+    def __init__(self, track: Track,
+                 loop: Optional[asyncio.AbstractEventLoop] = None,
+                 capacity: int = 0) -> None:
         self._track = track
-        self._ffi_queue = ffi_client.subscribe()
+        self._loop = loop or asyncio.get_event_loop()
+        self._ffi_queue = ffi_client.subscribe(self._loop)
         self._queue: RingQueue[AudioFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()
@@ -38,7 +42,7 @@ class AudioStream:
         self._ffi_handle = FfiHandle(stream_info.handle.id)
         self._info = stream_info
 
-        self._task = asyncio.create_task(self._run())
+        self._task = self._loop.create_task(self._run())
 
     async def _run(self):
         while True:

--- a/livekit/participant.py
+++ b/livekit/participant.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import ctypes
-from typing import Any, Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi
 from ._proto import participant_pb2 as proto_participant
 from ._proto.room_pb2 import DataPacketKind, TrackPublishOptions
+from ._utils import BroadcastQueue, wait_for
 from .track import LocalAudioTrack, LocalVideoTrack, Track
 from .track_publication import (
     LocalTrackPublication,
@@ -42,7 +43,7 @@ class PublishDataError(Exception):
         self.message = message
 
 
-class Participant():
+class Participant:
     def __init__(self, owned_info: proto_participant.OwnedParticipant) -> None:
         self._info = owned_info.info
         self._ffi_handle = FfiHandle(owned_info.handle.id)
@@ -65,17 +66,13 @@ class Participant():
         return self._info.metadata
 
 
-OnTrackPublishedType = Callable[[LocalTrackPublication, Track], Any]
-OnTrackUnpublishedType = Callable[[LocalTrackPublication], Any]
-
-
 class LocalParticipant(Participant):
-    def __init__(self, owned_info: proto_participant.OwnedParticipant, ) -> None:
+    def __init__(self,
+                 room_queue: BroadcastQueue,
+                 owned_info: proto_participant.OwnedParticipant) -> None:
         super().__init__(owned_info)
+        self._room_queue = room_queue
         self.tracks: dict[str, LocalTrackPublication] = {}  # type: ignore
-
-        self._on_track_published: OnTrackPublishedType = lambda pub, track: None
-        self._on_track_unpublished: OnTrackUnpublishedType = lambda pub: None
 
     async def publish_data(self,
                            payload: Union[bytes, str],
@@ -87,7 +84,6 @@ class LocalParticipant(Participant):
             payload = payload.encode('utf-8')
 
         data_len = len(payload)
-
         cdata = (ctypes.c_byte * data_len)(*payload)
 
         req = proto_ffi.FfiRequest()
@@ -106,10 +102,10 @@ class LocalParticipant(Participant):
 
             req.publish_data.destination_sids.extend(sids)
 
-        with ffi_client.observe() as obs:
+        with self._room_queue.observe() as obs:
             resp = ffi_client.request(req)
-            cb = await obs.wait_for(lambda e: e.publish_data.async_id ==
-                                    resp.publish_data.async_id)
+            cb = await wait_for(obs, lambda e: e.publish_data.async_id ==
+                                resp.publish_data.async_id)
 
         if cb.publish_data.error:
             raise PublishDataError(cb.publish_data.error)
@@ -125,10 +121,10 @@ class LocalParticipant(Participant):
         req.publish_track.local_participant_handle = self._ffi_handle.handle
         req.publish_track.options.CopyFrom(options)
 
-        with ffi_client.observe() as obs:
+        with self._room_queue.observe() as obs:
             resp = ffi_client.request(req)
-            cb = await obs.wait_for(lambda e: e.publish_track.async_id ==
-                                    resp.publish_track.async_id)
+            cb = wait_for(obs, lambda e: e.publish_track.async_id ==
+                          resp.publish_track.async_id)
 
         if cb.publish_track.error:
             raise PublishTrackError(cb.publish_track.error)
@@ -145,10 +141,10 @@ class LocalParticipant(Participant):
         req.unpublish_track.local_participant_handle = self._ffi_handle.handle
         req.unpublish_track.track_sid = track_sid
 
-        with ffi_client.observe() as obs:
+        with self._room_queue.observe() as obs:
             resp = ffi_client.request(req)
-            cb = await obs.wait_for(lambda e: e.unpublish_track.async_id ==
-                                    resp.unpublish_track.async_id)
+            cb = await wait_for(obs, lambda e: e.unpublish_track.async_id ==
+                                resp.unpublish_track.async_id)
 
         if cb.unpublish_track.error:
             raise UnpublishTrackError(cb.unpublish_track.error)

--- a/livekit/participant.py
+++ b/livekit/participant.py
@@ -124,8 +124,8 @@ class LocalParticipant(Participant):
 
         with self._room_queue.observe() as obs:
             resp = ffi_client.request(req)
-            cb = wait_for(obs, lambda e: e.publish_track.async_id ==
-                          resp.publish_track.async_id)
+            cb = await wait_for(obs, lambda e: e.publish_track.async_id ==
+                                resp.publish_track.async_id)
 
             if cb.publish_track.error:
                 raise PublishTrackError(cb.publish_track.error)

--- a/livekit/room.py
+++ b/livekit/room.py
@@ -167,9 +167,8 @@ class Room(EventEmitter):
             if self._room_queue.len_subscribers() > 0:
                 self._room_queue.put_nowait(event)
 
-                # wait for the queue to be empty
-                # so we can keep the order of events from the FfiServer
-                # (avoid scenario where the participant.py code handles events too late)
+                # wait for the subscribers to process the event
+                # before processing the next one
                 await self._room_queue.join()
 
     def _on_room_event(self, event: proto_room.RoomEvent):

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -29,7 +29,7 @@ class VideoStream:
                  capacity: int = 0) -> None:
         self._track = track
         self._loop = loop or asyncio.get_event_loop()
-        self._ffi_queue = ffi_client.subscribe(self._loop)
+        self._ffi_queue = ffi_client.channel.subscribe(self._loop)
         self._queue: RingQueue[VideoFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -29,7 +29,7 @@ class VideoStream:
                  capacity: int = 0) -> None:
         self._track = track
         self._loop = loop or asyncio.get_event_loop()
-        self._ffi_queue = ffi_client.channel.subscribe(self._loop)
+        self._ffi_queue = ffi_client.queue.subscribe(self._loop)
         self._queue: RingQueue[VideoFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()

--- a/livekit/video_stream.py
+++ b/livekit/video_stream.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from typing import Optional
 
 from ._ffi_client import FfiHandle, ffi_client
 from ._proto import ffi_pb2 as proto_ffi
@@ -23,9 +24,12 @@ from .video_frame import VideoFrame, VideoFrameBuffer
 
 
 class VideoStream:
-    def __init__(self, track: Track, capacity: int = 0) -> None:
+    def __init__(self, track: Track,
+                 loop: Optional[asyncio.AbstractEventLoop] = None,
+                 capacity: int = 0) -> None:
         self._track = track
-        self._ffi_queue = ffi_client.subscribe()
+        self._loop = loop or asyncio.get_event_loop()
+        self._ffi_queue = ffi_client.subscribe(self._loop)
         self._queue: RingQueue[VideoFrame] = RingQueue(capacity)
 
         req = proto_ffi.FfiRequest()
@@ -38,7 +42,7 @@ class VideoStream:
         self._ffi_handle = FfiHandle(stream_info.handle.id)
         self._info = stream_info.info
 
-        self._task = asyncio.create_task(self._run())
+        self._task = self._loop.create_task(self._run())
 
     async def _run(self):
         while True:


### PR DESCRIPTION
- Always ensure we keep the order from the FfiServer
   - So the complex logic can be handled from Rust (for synchronisation)
   - E.g: the ffi server ensure that the `LocalTrackPublished` callback is sent before the `LocalTrackPublished` event
- We know use only one FfiQueue per room (So it is possible for us to keep things synchronised)


The room musts be used inside one event_loop (specified inside the ctor)
AudioStream & VideoStream can be used on other event_loops (making it easy to have another IO thread for e.g)