### PR TITLE
Set rparticipant variable before emit event

### DIFF
--- a/livekit/room.py
+++ b/livekit/room.py
@@ -314,6 +314,7 @@ class Room(EventEmitter):
             
             data = bytearray(native_data)
             FfiHandle(owned_buffer_info.handle.id)
+            rparticipant = None
             if event.data_received.participant_sid:
                 rparticipant = self.participants[event.data_received.participant_sid]
             self.emit('data_received', data,


### PR DESCRIPTION
This PR sets the rparticipant variable to None in the `data_received` event. This addresses the error `Local variable referenced before assignment`. This may have negative effects in users callback functions if there isn't a None type check before referencing participant.  